### PR TITLE
feat: initialize and render game on codenames start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ all: build success
 build: ${BINARY}
 
 ${BINARY}: $(SOURCES)
-	go build -o ./bin/${BINARY} ${LDFLAGS} ./main.go
+	go build -o ./bin/${BINARY} ${LDFLAGS} ./cmd/*.go

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/jaredscheib/codenames"
+)
+
+func RenderGame(g codenames.Game) string {
+	var str string
+	str = str + fmt.Sprintf("%s Spymaster, it is your turn to offer a clue.", g.WhoseTurn)
+	str = str + "\n"
+	str = str + renderField(g.Field)
+	return str
+}
+
+func renderField(f []codenames.Codename) string {
+	var str string
+	for _, c := range f {
+		str = str + fmt.Sprintf("Type: %s, Value: %s, Visibility: %s", c.Type, c.Value, c.Visibility)
+		str = str + "\n"
+	}
+	return str
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	Execute()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jaredscheib/codenames/cli"
+	"github.com/jaredscheib/codenames/server"
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use: "start",
+	Run: func(cmd *cobra.Command, args []string) {
+		game := server.NewGame()
+		str := cli.RenderGame(game)
+		fmt.Println(str)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/codenames.go
+++ b/codenames.go
@@ -1,0 +1,33 @@
+package codenames
+
+type Codename struct {
+	// Position   string `json:"position"`
+	Type       string `json:"type"`
+	Value      string `json:"value"`
+	Visibility string `json:"visibility"`
+}
+
+type Player struct {
+	ID string `json:"id"`
+}
+
+type Team struct {
+	Color     string   `json:"color"`
+	Spymaster Player   `json:"spymaster"`
+	Teammates []Player `json:"teammates"`
+}
+
+type Teams struct {
+	Red  Team `json:"red"`
+	Blue Team `json:"blue"`
+}
+
+type Game struct {
+	WhoseTurn string     `json:"whoseTurn"`
+	Teams     Teams      `json:"teams"`
+	Field     []Codename `json:"field"`
+}
+
+func main() {
+
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/jaredscheib/codenames/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/openapi.yml
+++ b/openapi.yml
@@ -15,9 +15,12 @@ components:
             - "blueAgent"
             - "bystander"
             - "assassin"
-        isRevealed:
-          type: boolean
-          default: false
+        visibility:
+          type: string
+          enum: 
+            - "visible"
+            - "hidden"
+          default: "hidden"
         position:
           type: int8
         value:

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"github.com/jaredscheib/codenames"
+)
+
+func NewGame() codenames.Game {
+	// TODO: generate field of codenames
+	game := codenames.Game{
+		WhoseTurn: "Red",
+		Teams: codenames.Teams{
+			Red:  codenames.Team{Color: "Red"},
+			Blue: codenames.Team{Color: "Blue"},
+		},
+		Field: []codenames.Codename{
+			{
+				Type:       "Assassin",
+				Value:      "joe",
+				Visibility: "hidden",
+			},
+			{
+				Type:       "Bystander",
+				Value:      "bob",
+				Visibility: "visible",
+			},
+			{
+				Type:       "Red",
+				Value:      "helena",
+				Visibility: "hidden",
+			},
+			{
+				Type:       "Blue",
+				Value:      "jimmy",
+				Visibility: "visible",
+			},
+		},
+	}
+	return game
+}


### PR DESCRIPTION
Closes #3 

Game data is not valid or usable, but `codenames start` works.

This PR modifies the Makefile to build from the new file structure successfully.